### PR TITLE
impr: Isolate Redis in the docker network

### DIFF
--- a/config/.env
+++ b/config/.env
@@ -1,6 +1,6 @@
 # Redis
 # Set REDIS_ADDR to localhost:6379 if running outside of Docker
-REDIS_ADDR=localhost:6379
+REDIS_ADDR=database:6379
 REDIS_PASS=# this one can be left empty
 
 # Heartbeat

--- a/config/.env
+++ b/config/.env
@@ -1,6 +1,6 @@
 # Redis
 # Set REDIS_ADDR to localhost:6379 if running outside of Docker
-REDIS_ADDR=database:6379
+REDIS_ADDR=localhost:6379
 REDIS_PASS=# this one can be left empty
 
 # Heartbeat

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     image: l1ving/heartbeat
     volumes:
       - "./config:/heartbeat/config"
+    networks:
+      - heartbeat-net
     ports:
       - "6060:6060"
     build:
@@ -17,10 +19,14 @@ services:
       - "redis_data:/data"
       - "./config/redis.conf:/heartbeat/config/redis.conf"
     command: "/heartbeat/config/redis.conf --loadmodule /usr/lib/redis/modules/rejson.so"
+    networks:
+      - heartbeat-net
     expose:
       - 6379
-    ports:
-      - "6379:6379"
 
 volumes:
   redis_data:
+
+networks:
+  heartbeat-net:
+    driver: bridge


### PR DESCRIPTION
I'm using networks here, this will make redis inaccessible from the host, but accessible to the heartbeat app (inside 'heartbeat-net')